### PR TITLE
Improved Levenshtein string comparison score with FuzzyWuzzy (#6, #20)

### DIFF
--- a/app/src/main/java/de/lmu/navigator/search/FuzzyWuzzyStringMetric.java
+++ b/app/src/main/java/de/lmu/navigator/search/FuzzyWuzzyStringMetric.java
@@ -1,0 +1,44 @@
+package de.lmu.navigator.search;
+
+import java.util.Locale;
+
+import me.xdrop.fuzzywuzzy.FuzzySearch;
+import uk.ac.shef.wit.simmetrics.similaritymetrics.AbstractStringMetric;
+
+/**
+ * See: https://github.com/xdrop/fuzzywuzzy
+ */
+public class FuzzyWuzzyStringMetric extends AbstractStringMetric {
+
+    @Override
+    public String getLongDescriptionString() {
+        return null;
+    }
+
+    @Override
+    public String getShortDescriptionString() {
+        return null;
+    }
+
+    @Override
+    public float getSimilarity(String compString, String searchString) {
+        // Give score independent of position in word and order of search words
+        return FuzzySearch.tokenSortPartialRatio(searchString.toLowerCase(Locale.GERMAN), compString.toLowerCase(Locale.GERMAN)) / 100f;
+    }
+
+    @Override
+    public String getSimilarityExplained(String arg0, String arg1) {
+        return null;
+    }
+
+    @Override
+    public float getSimilarityTimingEstimated(String arg0, String arg1) {
+        return 0;
+    }
+
+    @Override
+    public float getUnNormalisedSimilarity(String compString,
+                                           String searchString) {
+        return 0;
+    }
+}

--- a/app/src/main/java/de/lmu/navigator/search/SearchScore.java
+++ b/app/src/main/java/de/lmu/navigator/search/SearchScore.java
@@ -1,8 +1,11 @@
 package de.lmu.navigator.search;
 
+import uk.ac.shef.wit.simmetrics.similaritymetrics.AbstractStringMetric;
+
 public class SearchScore implements Comparable<SearchScore> {
     private final static float MATCH_THRESHOLD = 0.5f;
-    private static MyPrefixLevenshtein mSimilarityMeasure = new MyPrefixLevenshtein();
+    private final static boolean FUZZYWUZZY_STRING_METRIC = true;
+    private static AbstractStringMetric mSimilarityMeasure = FUZZYWUZZY_STRING_METRIC ? new FuzzyWuzzyStringMetric() : new MyPrefixLevenshtein();
 
     private Searchable mSearchable;
     private float simPrimary = 1f;

--- a/app/src/main/res/raw/licences
+++ b/app/src/main/res/raw/licences
@@ -73,6 +73,12 @@
         <license>Apache Software License 2.0</license>
     </notice>
     <notice>
+        <name>JavaWuzzy</name>
+        <url>https://github.com/xdrop/fuzzywuzzy</url>
+        <copyright/>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
         <name>SimMetrics</name>
         <url>http://sourceforge.net/projects/simmetrics/</url>
         <copyright/>


### PR DESCRIPTION
Solves #20,
and #6 partially.
- [x] _Leerzeichen bei Suche ignorieren (wenn man nacht "e110" sucht, sollte auch Raum "E 110" gefunden werden)_ 
Maybe not the first enty, but in the list. But always shows more relevant results.
- [x] _Auch Teil-Strings unterstützen (wenn man z.B. nur nach "101" sucht, sollte auch Raum "A 101" gefunden werden)_
- [ ] _Simmetrics library austauschen (z.B. gegen diese: https://github.com/Simmetrics/simmetrics)_
Simmetrics can now be removed, if wanted, but was replaced with https://github.com/xdrop/fuzzywuzzy (Note: have to create a own `StringMetric` interface with `getSimilarity` method, if removing)
- [ ] _Performance verbessern_
Works quite fast, so maybe its solved, too.

Can even permut and cut words / numbers.