### PR TITLE
WIP: Room / building synonyms integration (#21)

### DIFF
--- a/app/src/debug/java/de/lmu/navigator/DataConfig.java
+++ b/app/src/debug/java/de/lmu/navigator/DataConfig.java
@@ -4,7 +4,7 @@ public final class DataConfig {
 
     private DataConfig() { }
 
-    public final static int SHIPPED_DATA_VERSION = 3;
+    public final static int SHIPPED_DATA_VERSION = 4;
 
 //    public static final String TILES_BASE_PATH = "http://lm00000-rfinder.srv.mwn.de/files/tiles/v3/";
 //    public static final String PHOTO_BASE_PATH = "http://lm00000-rfinder.srv.mwn.de/files/photos/";

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,11 @@
             android:screenOrientation="portrait"
             android:theme="@style/AppTheme.TransparentActionBar"/>
         <activity
+            android:name=".search.SearchAllActivity"
+            android:label="@string/search_label"
+            android:screenOrientation="portrait">
+        </activity>
+        <activity
             android:name=".search.SearchBuildingActivity"
             android:label="@string/search_label"
             android:screenOrientation="portrait">

--- a/app/src/main/assets/data/23_building_syn.json
+++ b/app/src/main/assets/data/23_building_syn.json
@@ -1,0 +1,30 @@
+[
+  {
+    "bCode": "bw0000",
+    "syn": "Hauptgebäude"
+  },
+  {
+    "bCode": "bw1003",
+    "syn": "Mathebau"
+  },
+  {
+    "bCode": "bw0601",
+    "syn": "Fakultät für Psychologie und Pädagogik"
+  },
+  {
+    "bCode": "bw0601",
+    "syn": "Schweinchenbau"
+  },
+  {
+    "bCode": "bw1715",
+    "syn": "Pathologisches Institut"
+  },
+  {
+    "bCode": "TODO",
+    "syn": "Philologicum"
+  },
+  {
+    "bCode": "bw0120",
+    "syn": "Institut für Statistik"
+  }
+]

--- a/app/src/main/assets/data/26_room_syn.json
+++ b/app/src/main/assets/data/26_room_syn.json
@@ -1,0 +1,78 @@
+[
+  {
+    "rCode": "000000100_",
+    "syn": "Audimax"
+  },
+  {
+    "rCode": "000000027_",
+    "syn": "Lichthof"
+  },
+  {
+    "rCode": "0010-1097_",
+    "syn": "Stucafé"
+  },
+  {
+    "rCode": "001900001_",
+    "syn": "Studienkanzlei"
+  },
+  {
+    "rCode": "001901226_",
+    "syn": "Große Aula"
+  },
+  {
+    "rCode": "001901238_",
+    "syn": "Senatssaal"
+  },
+  {
+    "rCode": "002000020_",
+    "syn": "Kleiner Physikhörsaal"
+  },
+  {
+    "rCode": "002001120_",
+    "syn": "Großer Physikhörsaal"
+  },
+  {
+    "rCode": "TODO",
+    "syn": "Universitätsbibliothek"
+  },
+  {
+    "rCode": "100200029_",
+    "syn": "Café Gumbel"
+  },
+  {
+    "rCode": "100200038_",
+    "syn": "GAF"
+  },
+  {
+    "rCode": "7078-1014_",
+    "syn": "CIP-Pool Sibirien"
+  },
+  {
+    "rCode": "7078-1012_",
+    "syn": "CIP-Pool Gobi"
+  },
+  {
+    "rCode": "7078-1017_",
+    "syn": "CIP-Pool Takla-Makan"
+  },
+  {
+    "rCode": "7080-1102_",
+    "syn": "CIP-Pool Kalahari"
+  },
+  {
+    "rCode": "708100001_",
+    "syn": "CIP-Pool Antarktis"
+  },
+  {
+    "rCode": "708100005_",
+    "syn": "CIP-Pool Arktis"
+  },
+  {
+    "rCode": "100201015_",
+    "syn": "CIP-Pool Proxima"
+  },
+  {
+    "rCode": "102000001_",
+    "syn": "CIP-Pool Luna"
+  }
+]

--- a/app/src/main/java/de/lmu/navigator/app/AllBuildingsAdapter.java
+++ b/app/src/main/java/de/lmu/navigator/app/AllBuildingsAdapter.java
@@ -32,8 +32,8 @@ public class AllBuildingsAdapter extends BuildingsAdapter {
     @Override
     protected void onBindBilduing(RecyclerView.ViewHolder vh, Building building) {
         AllBuildingsAdapter.ViewHolder holder = (AllBuildingsAdapter.ViewHolder) vh;
-        holder.city.setText(building.getStreet().getCity().getName());
-        holder.street.setText(building.getDisplayName());
+        holder.city.setText(ModelHelper.getDescription(building));
+        holder.street.setText(ModelHelper.getName(building));
 
         int imageSize = mContext.getResources().getDimensionPixelSize(R.dimen.image_size_all);
         Picasso.get()

--- a/app/src/main/java/de/lmu/navigator/app/BuildingDetailActivity.java
+++ b/app/src/main/java/de/lmu/navigator/app/BuildingDetailActivity.java
@@ -59,8 +59,8 @@ public class BuildingDetailActivity extends BaseActivity {
         mBuilding = mDatabaseManager.getBuilding(extraBuildingCode);
 
         setTitle(null);
-        mBuildingName.setText(mBuilding.getDisplayName());
-        mBuildingCity.setText(mBuilding.getStreet().getCity().getName());
+        mBuildingName.setText(ModelHelper.getName(mBuilding));
+        mBuildingCity.setText(ModelHelper.getDescription(mBuilding));
 
         final Drawable placeholder = TextDrawable.builder()
                 .beginConfig()
@@ -69,7 +69,7 @@ public class BuildingDetailActivity extends BaseActivity {
                             .getDimensionPixelSize(R.dimen.building_placeholder_font_size))
                     .toUpperCase()
                 .endConfig()
-                .buildRect(mBuilding.getDisplayName().substring(0, 1),
+                .buildRect(ModelHelper.getName(mBuilding).substring(0, 1),
                         ColorGenerator.MATERIAL.getColor(mBuilding));
 
         Picasso.get()
@@ -94,7 +94,7 @@ public class BuildingDetailActivity extends BaseActivity {
     @OnClick(R.id.layout_map)
     void showMap() {
         String url = String.format("http://maps.google.com/maps?geo:%s%s&q=%s",
-                mBuilding.getCoordLat(), mBuilding.getCoordLong(), mBuilding.getDisplayName());
+                mBuilding.getCoordLat(), mBuilding.getCoordLong(), mBuilding.getName());
         Intent intent = new Intent(android.content.Intent.ACTION_VIEW, Uri.parse(url));
         startActivity(intent);
     }

--- a/app/src/main/java/de/lmu/navigator/app/BuildingsAdapter.java
+++ b/app/src/main/java/de/lmu/navigator/app/BuildingsAdapter.java
@@ -9,6 +9,7 @@ import android.view.View;
 import com.amulyakhare.textdrawable.TextDrawable;
 import com.amulyakhare.textdrawable.util.ColorGenerator;
 
+import de.lmu.navigator.database.ModelHelper;
 import de.lmu.navigator.database.model.Building;
 import de.lmu.navigator.view.RealmAdapter;
 import io.realm.RealmResults;
@@ -56,6 +57,6 @@ public abstract class BuildingsAdapter extends RealmAdapter<Building> {
                     .width(size)
                     .height(size)
                 .endConfig()
-                .buildRound(b.getDisplayName().substring(0, 1), color);
+                .buildRound(ModelHelper.getName(b).substring(0, 1), color);
     }
 }

--- a/app/src/main/java/de/lmu/navigator/app/FavoritesAdapter.java
+++ b/app/src/main/java/de/lmu/navigator/app/FavoritesAdapter.java
@@ -32,7 +32,7 @@ public class FavoritesAdapter extends BuildingsAdapter {
     @Override
     protected void onBindBilduing(RecyclerView.ViewHolder vh, Building building) {
         FavoritesAdapter.ViewHolder holder = (FavoritesAdapter.ViewHolder) vh;
-        holder.name.setText(building.getDisplayName());
+        holder.name.setText(ModelHelper.getName(building));
 
         int imageSize = mContext.getResources().getDimensionPixelSize(R.dimen.image_size_favorite);
         Picasso.get()

--- a/app/src/main/java/de/lmu/navigator/app/LaunchActivity.java
+++ b/app/src/main/java/de/lmu/navigator/app/LaunchActivity.java
@@ -19,6 +19,8 @@ import de.lmu.navigator.DataConfig;
 import de.lmu.navigator.R;
 import de.lmu.navigator.database.UpdateService;
 import de.lmu.navigator.preferences.Preferences;
+import io.realm.Realm;
+import io.realm.RealmConfiguration;
 import me.alexrs.prefs.lib.Prefs;
 
 public class LaunchActivity extends AppCompatActivity {
@@ -48,6 +50,15 @@ public class LaunchActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        // Always set realm schema version
+        RealmConfiguration config = new RealmConfiguration.Builder()
+                .name("default.realm")
+                .schemaVersion(DataConfig.SHIPPED_DATA_VERSION)
+                .deleteRealmIfMigrationNeeded()
+                .build();
+        Realm.setDefaultConfiguration(config);
+        // TODO add migration, if don't want to delete old db.
 
         if (shouldUpdate()) {
             setContentView(R.layout.activity_launch);

--- a/app/src/main/java/de/lmu/navigator/database/RealmDatabaseManager.java
+++ b/app/src/main/java/de/lmu/navigator/database/RealmDatabaseManager.java
@@ -102,6 +102,10 @@ public class RealmDatabaseManager {
         return rooms;
     }
 
+    public List<Room> getRoomsWithSynonym() {
+        return mRealm.where(Room.class).isNotEmpty(ModelHelper.SYNONYMS).findAll();
+    }
+
     private List<Floor> getFloorsForBuilding(Building b) {
         return mRealm.where(Floor.class)
                 .equalTo(ModelHelper.FLOOR_BUILDING_CODE, b.getCode())

--- a/app/src/main/java/de/lmu/navigator/database/model/Building.java
+++ b/app/src/main/java/de/lmu/navigator/database/model/Building.java
@@ -2,13 +2,15 @@ package de.lmu.navigator.database.model;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.util.List;
+
 import io.realm.RealmList;
 import io.realm.RealmObject;
 import io.realm.annotations.Ignore;
 import io.realm.annotations.PrimaryKey;
 import io.realm.annotations.Required;
 
-public class Building extends RealmObject {
+public class Building extends RealmObject implements Synonymable<Building> {
 
     @Required
     @PrimaryKey
@@ -20,7 +22,8 @@ public class Building extends RealmObject {
     private String streetCode;
 
     @Required
-    private String displayName;
+    @SerializedName("displayName")
+    private String name;
 
     @SerializedName("lat")
     private double coordLat;
@@ -31,6 +34,8 @@ public class Building extends RealmObject {
     private boolean starred = false;
 
     private RealmList<BuildingPart> buildingParts = new RealmList<>();
+
+    private RealmList<BuildingSynonym> synonyms = new RealmList<>();
 
     public RealmList<BuildingPart> getBuildingParts() {
         return buildingParts;
@@ -56,12 +61,13 @@ public class Building extends RealmObject {
         this.street = street;
     }
 
-    public String getDisplayName() {
-        return displayName;
+    @Override
+    public String getName() {
+        return name;
     }
 
-    public void setDisplayName(String displayName) {
-        this.displayName = displayName;
+    public void setName(String name) {
+        this.name = name;
     }
 
     public double getCoordLat() {
@@ -94,5 +100,19 @@ public class Building extends RealmObject {
 
     public void setStreetCode(String streetCode) {
         this.streetCode = streetCode;
+    }
+
+    @Override
+    public List<BuildingSynonym> getSynonyms() {
+        return synonyms;
+    }
+
+    @Override
+    public boolean hasSynonyms() {
+        return synonyms.size() > 0;
+    }
+
+    public void setSynonyms(RealmList<BuildingSynonym> synonyms) {
+        this.synonyms = synonyms;
     }
 }

--- a/app/src/main/java/de/lmu/navigator/database/model/BuildingSynonym.java
+++ b/app/src/main/java/de/lmu/navigator/database/model/BuildingSynonym.java
@@ -1,0 +1,50 @@
+package de.lmu.navigator.database.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import io.realm.RealmObject;
+import io.realm.annotations.Ignore;
+import io.realm.annotations.Required;
+
+public class BuildingSynonym extends RealmObject implements RealmLeaf<Building> {
+
+    protected Building parent;
+
+    @Ignore
+    @SerializedName("bCode")
+    protected String parentId;
+
+    @Required
+    @SerializedName("syn")
+    protected String name;
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public Building getParent() {
+        return parent;
+    }
+
+    @Override
+    public void setParent(Building parent) {
+        this.parent = parent;
+    }
+
+    @Override
+    public String getParentId() {
+        return parentId;
+    }
+
+    @Override
+    public void setParentId(String parentId) {
+        this.parentId = parentId;
+    }
+}

--- a/app/src/main/java/de/lmu/navigator/database/model/RealmLeaf.java
+++ b/app/src/main/java/de/lmu/navigator/database/model/RealmLeaf.java
@@ -1,0 +1,22 @@
+package de.lmu.navigator.database.model;
+
+/**
+ * This interface specifies the last element in a Realm tree, as it only has a parent, but no child elements.
+ * TODO make to abstract class if polymorphism is supported: https://github.com/realm/realm-java/issues/761
+ *
+ * @param <T> the type of the parent element.
+ */
+public interface RealmLeaf<T> {
+
+    String getName();
+
+    void setName(String name);
+
+    T getParent();
+
+    void setParent(T parent);
+
+    String getParentId();
+
+    void setParentId(String parentId);
+}

--- a/app/src/main/java/de/lmu/navigator/database/model/Room.java
+++ b/app/src/main/java/de/lmu/navigator/database/model/Room.java
@@ -1,11 +1,14 @@
 package de.lmu.navigator.database.model;
 
+import java.util.List;
+
+import io.realm.RealmList;
 import io.realm.RealmObject;
 import io.realm.annotations.Ignore;
 import io.realm.annotations.PrimaryKey;
 import io.realm.annotations.Required;
 
-public class Room extends RealmObject {
+public class Room extends RealmObject implements Synonymable<Room>{
 
     @Required
     @PrimaryKey
@@ -23,6 +26,8 @@ public class Room extends RealmObject {
 
     private int posY;
 
+    private RealmList<RoomSynonym> synonyms = new RealmList<>();
+
     public String getCode() {
         return code;
     }
@@ -39,6 +44,7 @@ public class Room extends RealmObject {
         this.floor = floor;
     }
 
+    @Override
     public String getName() {
         return name;
     }
@@ -69,5 +75,19 @@ public class Room extends RealmObject {
 
     public void setFloorCode(String floorCode) {
         this.floorCode = floorCode;
+    }
+
+    @Override
+    public List<RoomSynonym> getSynonyms() {
+        return synonyms;
+    }
+
+    @Override
+    public boolean hasSynonyms() {
+        return synonyms.size() > 0;
+    }
+
+    public void setSynonyms(RealmList<RoomSynonym> synonyms) {
+        this.synonyms = synonyms;
     }
 }

--- a/app/src/main/java/de/lmu/navigator/database/model/RoomSynonym.java
+++ b/app/src/main/java/de/lmu/navigator/database/model/RoomSynonym.java
@@ -1,0 +1,50 @@
+package de.lmu.navigator.database.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import io.realm.RealmObject;
+import io.realm.annotations.Ignore;
+import io.realm.annotations.Required;
+
+public class RoomSynonym extends RealmObject implements RealmLeaf<Room> {
+
+    @Ignore
+    @SerializedName("rCode")
+    protected String parentId;
+
+    @Required
+    @SerializedName("syn")
+    protected String name;
+
+    protected Room parent;
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public Room getParent() {
+        return parent;
+    }
+
+    @Override
+    public void setParent(Room parent) {
+        this.parent = parent;
+    }
+
+    @Override
+    public String getParentId() {
+        return parentId;
+    }
+
+    @Override
+    public void setParentId(String parentId) {
+        this.parentId = parentId;
+    }
+}

--- a/app/src/main/java/de/lmu/navigator/database/model/Synonymable.java
+++ b/app/src/main/java/de/lmu/navigator/database/model/Synonymable.java
@@ -1,0 +1,21 @@
+package de.lmu.navigator.database.model;
+
+import java.util.List;
+
+/**
+ * Interface to avoid duplicate code fragments for "synonymable" elements.
+ *
+ * @param <T> The class of the database elements, which can have synonyms.
+ */
+public interface Synonymable<T extends Synonymable<T>> {
+
+    boolean hasSynonyms();
+
+    /**
+     * @param <U> the class of the synonym (of type T)
+     * @return
+     */
+    <U extends RealmLeaf<T>> List<U> getSynonyms();
+
+    String getName();
+}

--- a/app/src/main/java/de/lmu/navigator/indoor/FloorViewActivity.java
+++ b/app/src/main/java/de/lmu/navigator/indoor/FloorViewActivity.java
@@ -10,6 +10,7 @@ import android.view.MenuItem;
 import butterknife.ButterKnife;
 import de.lmu.navigator.R;
 import de.lmu.navigator.app.BaseActivity;
+import de.lmu.navigator.database.ModelHelper;
 import de.lmu.navigator.database.model.Building;
 import de.lmu.navigator.database.model.Room;
 import de.lmu.navigator.search.AbsSearchActivity;
@@ -60,7 +61,7 @@ public class FloorViewActivity extends BaseActivity {
                     .commit();
         }
 
-        setTitle(mBuilding.getDisplayName());
+        setTitle(ModelHelper.getName(mBuilding));
     }
 
     public TileViewFragment getTileViewFragment() {

--- a/app/src/main/java/de/lmu/navigator/indoor/TileViewFragment.java
+++ b/app/src/main/java/de/lmu/navigator/indoor/TileViewFragment.java
@@ -364,8 +364,8 @@ public class TileViewFragment extends BaseFragment implements TileViewEventListe
         mTileView.scrollToAndCenter(room.getPosX(), room.getPosY());
 
         mRoomDetailView.setVisibility(View.VISIBLE);
-        mRoomDetailName.setText(getString(R.string.floorview_selected_room, room.getName()));
-        mRoomDetailFloor.setText(room.getFloor().getName());
+        mRoomDetailName.setText(ModelHelper.getName(room, getString(R.string.floorview_selected_room)));
+        mRoomDetailFloor.setText(ModelHelper.getDescription(room));
 
         mSelectedRoom = room;
     }

--- a/app/src/main/java/de/lmu/navigator/map/BuildingItem.java
+++ b/app/src/main/java/de/lmu/navigator/map/BuildingItem.java
@@ -37,12 +37,12 @@ public class BuildingItem implements ClusterItem {
 
     @Override
     public String getTitle() {
-        return mBuilding.getDisplayName();
+        return ModelHelper.getName(mBuilding);
     }
 
     @Override
     public String getSnippet() {
-        return mBuilding.getStreet().getCity().getName();
+        return ModelHelper.getDescription(mBuilding);
     }
 
     @Override

--- a/app/src/main/java/de/lmu/navigator/map/ClusterMapFragment.java
+++ b/app/src/main/java/de/lmu/navigator/map/ClusterMapFragment.java
@@ -31,6 +31,7 @@ import java.util.List;
 import de.lmu.navigator.R;
 import de.lmu.navigator.app.BuildingDetailActivity;
 import de.lmu.navigator.app.MainActivity;
+import de.lmu.navigator.database.ModelHelper;
 import de.lmu.navigator.database.model.Building;
 import io.realm.RealmResults;
 
@@ -201,7 +202,7 @@ public class ClusterMapFragment extends SupportMapFragment implements
             mDialogClusterItems = Lists.newArrayList(cluster.getItems());
             String[] items = new String[cluster.getSize()];
             for (int i = 0; i < mDialogClusterItems.size(); i++) {
-                items[i] = mDialogClusterItems.get(i).getBuilding().getDisplayName();
+                items[i] = ModelHelper.getName(mDialogClusterItems.get(i).getBuilding());
             }
 
             new AlertDialog.Builder(getActivity())

--- a/app/src/main/java/de/lmu/navigator/preferences/Preferences.java
+++ b/app/src/main/java/de/lmu/navigator/preferences/Preferences.java
@@ -12,6 +12,10 @@ public final class Preferences {
 
     public static final String KEY_CRASH_REPORTS = "key_crash_reports";
 
+    public static final String KEY_DISPLAY_SYNONYM = "key_display_synonym";
+
+    public static final String KEY_SEARCH_ADVANCED = "key_search_advanced";
+
     private Preferences() {}
 
 }

--- a/app/src/main/java/de/lmu/navigator/preferences/SettingsActivity.java
+++ b/app/src/main/java/de/lmu/navigator/preferences/SettingsActivity.java
@@ -2,11 +2,16 @@ package de.lmu.navigator.preferences;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import androidx.appcompat.app.AppCompatActivity;
+
+import android.preference.PreferenceManager;
 import android.view.MenuItem;
 
-public class SettingsActivity extends AppCompatActivity {
+import de.lmu.navigator.database.ModelHelper;
+
+public class SettingsActivity extends AppCompatActivity implements SharedPreferences.OnSharedPreferenceChangeListener {
 
     public static Intent newIntent(Context context) {
         return new Intent(context, SettingsActivity.class);
@@ -15,6 +20,7 @@ public class SettingsActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        PreferenceManager.getDefaultSharedPreferences(this).registerOnSharedPreferenceChangeListener(this);
         getFragmentManager().beginTransaction()
                 .replace(android.R.id.content, new SettingsFragment())
                 .commit();
@@ -27,6 +33,14 @@ public class SettingsActivity extends AppCompatActivity {
             return true;
         } else {
             return super.onOptionsItemSelected(item);
+        }
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+        if(Preferences.KEY_DISPLAY_SYNONYM.equals(key)){
+            ModelHelper.displaySynonyms = sharedPreferences.getBoolean(key, true);
+            // TODO invalidate main view
         }
     }
 }

--- a/app/src/main/java/de/lmu/navigator/search/AbsSearchActivity.java
+++ b/app/src/main/java/de/lmu/navigator/search/AbsSearchActivity.java
@@ -46,6 +46,7 @@ public abstract class AbsSearchActivity extends BaseActivity
     private static final String LOG_TAG = AbsSearchActivity.class.getSimpleName();
 
     public static final String KEY_SEARCH_RESULT = "KEY_SEARCH_RESULT";
+    public static final String CLASS_NAME = "CLASS_NAME";
 
     @BindView(R.id.recycler)
     RecyclerView mRecyclerView;
@@ -120,6 +121,7 @@ public abstract class AbsSearchActivity extends BaseActivity
     public void onItemClick(Searchable item) {
         Intent result = new Intent();
         result.putExtra(KEY_SEARCH_RESULT, item.getCode());
+        result.putExtra(CLASS_NAME, item.getClassName());
         setResult(RESULT_OK, result);
 
         finish();

--- a/app/src/main/java/de/lmu/navigator/search/SearchAllActivity.java
+++ b/app/src/main/java/de/lmu/navigator/search/SearchAllActivity.java
@@ -1,0 +1,40 @@
+package de.lmu.navigator.search;
+
+import android.content.Context;
+import android.content.Intent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import de.lmu.navigator.R;
+import de.lmu.navigator.database.RealmDatabaseManager;
+import de.lmu.navigator.database.model.Building;
+import de.lmu.navigator.database.model.Room;
+
+public class SearchAllActivity extends AbsSearchActivity {
+
+    public static Intent newIntent(Context context) {
+        return new Intent(context, SearchAllActivity.class);
+    }
+
+    @Override
+    public List<Searchable> getItems() {
+        List<Searchable> items = new ArrayList<>();
+        RealmDatabaseManager databaseManager = new RealmDatabaseManager();
+        // Search for buildings
+        for (Building b : databaseManager.getAllBuildings()) {
+            items.add(SearchableWrapper.wrap(b));
+        }
+        // Search for named rooms
+        for (Room r : databaseManager.getRoomsWithSynonym()) {
+            items.add(SearchableWrapper.wrap(r, null));
+        }
+        databaseManager.close();
+        return items;
+    }
+
+    @Override
+    public int getSearchHintResId() {
+        return R.string.search_hint_buildings;
+    }
+}

--- a/app/src/main/java/de/lmu/navigator/search/SearchRoomActivity.java
+++ b/app/src/main/java/de/lmu/navigator/search/SearchRoomActivity.java
@@ -31,6 +31,8 @@ public class SearchRoomActivity extends AbsSearchActivity {
         Building building = databaseManager.getBuilding(buildingCode);
 
         List<Room> rooms = databaseManager.getRoomsForBuilding(building, true, true);
+
+        // If same parent exists in different building parts, add building part as hint in description
         SetMultimap<String, String> roomNamesMap = HashMultimap.create();
         for (Room r : rooms) {
             roomNamesMap.put(r.getName(), r.getFloor().getBuildingPart().getName());

--- a/app/src/main/java/de/lmu/navigator/search/Searchable.java
+++ b/app/src/main/java/de/lmu/navigator/search/Searchable.java
@@ -7,4 +7,6 @@ public interface Searchable {
     String getSecondaryText();
 
     String getCode();
+
+    String getClassName();
 }

--- a/app/src/main/java/de/lmu/navigator/search/SearchableWrapper.java
+++ b/app/src/main/java/de/lmu/navigator/search/SearchableWrapper.java
@@ -1,5 +1,6 @@
 package de.lmu.navigator.search;
 
+import de.lmu.navigator.database.ModelHelper;
 import de.lmu.navigator.database.model.Building;
 import de.lmu.navigator.database.model.Room;
 
@@ -11,6 +12,8 @@ public class SearchableWrapper implements Searchable {
 
     private String mCode;
 
+    private String mClassName;
+
     public static Searchable wrap(Room room, String buildingPartHint) {
         return new SearchableWrapper(room, buildingPartHint);
     }
@@ -20,9 +23,10 @@ public class SearchableWrapper implements Searchable {
     }
 
     private SearchableWrapper(Room room, String buildingPartHint) {
-        mPrimaryText = room.getName();
-        mSecondaryText = room.getFloor().getName();
+        mPrimaryText = ModelHelper.getName(room);
+        mSecondaryText = ModelHelper.getDescription(room);
         mCode = room.getCode();
+        mClassName = Room.class.getSimpleName();
 
         if (buildingPartHint != null) {
             mSecondaryText = mSecondaryText + " (" + buildingPartHint + ")";
@@ -30,9 +34,10 @@ public class SearchableWrapper implements Searchable {
     }
 
     private SearchableWrapper(Building building) {
-        mPrimaryText = building.getDisplayName();
-        mSecondaryText = building.getStreet().getCity().getName();
+        mPrimaryText = ModelHelper.getName(building);
+        mSecondaryText = ModelHelper.getDescription(building);
         mCode = building.getCode();
+        mClassName = Building.class.getSimpleName();
     }
 
 
@@ -49,5 +54,10 @@ public class SearchableWrapper implements Searchable {
     @Override
     public String getCode() {
         return mCode;
+    }
+
+    @Override
+    public String getClassName() {
+        return mClassName;
     }
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -40,6 +40,10 @@
     <string name="prefs_categroy_general">Allgemein</string>
     <string name="prefs_crash_logs_title">Crash Logs und Statistiken senden</string>
     <string name="prefs_crash_logs_summary">Anonyme Absturzberichte und Statistiken helfen uns, Fehler schneller zu beseitigen und die App zu verbessern. Es werden keine privaten Daten gesammelt.</string>
+    <string name="prefs_display_synonym_title">Namen im Titel anzeigen</string>
+    <string name="prefs_display_synonym_summary">Wenn Synonyme für Räume und Gebäude verfügbar sind, zeige diese als Titel und füge die Adressinformation der Beschreibung hinzu.</string>
+    <string name="prefs_search_advanced_title">Erweiterte Suche</string>
+    <string name="prefs_search_advanced_summary">Auch benannte Räume in der Hauptsuche berücksichtigen</string>
     <string name="prefs_category_information">Informationen</string>
     <string name="prefs_licences_title">Open-Source-Lizenzen</string>
     <string name="prefs_feedback_title">Feedback geben</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,10 @@
     <string name="prefs_categroy_general">General</string>
     <string name="prefs_crash_logs_title">Send crash logs and statistics</string>
     <string name="prefs_crash_logs_summary">Anonymous crash reports and statistics help us to find bugs quicker and to improve the app. No private data is collected.</string>
+    <string name="prefs_display_synonym_title">Display name in title</string>
+    <string name="prefs_display_synonym_summary">If synonyms of rooms and buildings are available, show them as title and add the address info to the description.</string>
+    <string name="prefs_search_advanced_title">Advanced search</string>
+    <string name="prefs_search_advanced_summary">Also include named rooms in main search.</string>
     <string name="prefs_category_information">Information</string>
     <string name="prefs_licences_title">Open-Source-Licences</string>
     <string name="prefs_feedback_title">Give feedback</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -11,6 +11,18 @@
             android:summary="@string/prefs_crash_logs_summary"
             android:defaultValue="true"/>
 
+        <SwitchPreference
+            android:key="key_display_synonym"
+            android:title="@string/prefs_display_synonym_title"
+            android:summary="@string/prefs_display_synonym_summary"
+            android:defaultValue="true"/>
+
+        <SwitchPreference
+            android:key="key_search_advanced"
+            android:title="@string/prefs_search_advanced_title"
+            android:summary="@string/prefs_search_advanced_summary"
+            android:defaultValue="true"/>
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
See #21,
Features:
- Synonyms for rooms
- Synonyms for buildings
- Display synonyms instead of address data (optional in settings)
- Search also for rooms with synonyms in main search (optional in settings)

I know that users cannot tag their own buildings / rooms, but if wanted, the json can be extended via new issues or own PRs. Also the data has to be transfered to the web / ios version (via db).

Drawbacks:
- Database has to be deleted, or a [migration ](https://realm.io/docs/java/latest/#configuring-a-realm) has to be performed.

Apparently not all the naming data is provided, so help from other students is appreciated.
Of course this is much in one PR, so can split them in separate commits / PRs.
Please give me feedback. Thx.